### PR TITLE
Added close() method for WsSender on WASM targets

### DIFF
--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -29,6 +29,12 @@ impl WsSender {
             tracing::error!("Failed to send: {:?}", err);
         }
     }
+
+    /// On WASM targets the WebSocket will not be closed when the last reference to WsSender is dropped.
+    pub fn close(&mut self) -> Result<()> {
+        let result = self.ws.close();
+        result.map_err(string_from_js_value)
+    }
 }
 
 /// Call the given event handler on each new received event.


### PR DESCRIPTION
After some testing I've found that the WebSockets do not close when dropping all references to them on WASM targets. I'm not sure whats keeping them alive, but I propose allowing a manual close in the meantime.