### PR TITLE
Update eframe, add trunk setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/**/dist/*

--- a/example_app/Cargo.toml
+++ b/example_app/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 ewebsock = { path = "../ewebsock", features = ["tls"] }
 
-eframe = "0.17.0" # Gives us egui, epi and web+native backends
+eframe = "0.21.3" # Gives us egui, epi and web+native backends
 tracing = "0.1"
 
 # native:

--- a/example_app/Cargo.toml
+++ b/example_app/Cargo.toml
@@ -27,3 +27,4 @@ tracing-subscriber = "0.3"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2"
+wasm-bindgen-futures = "0.4"

--- a/example_app/index.html
+++ b/example_app/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+<!-- Disable zooming: -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+
+<head>
+    <!-- change this to your project name -->
+    <title>ewebsock test app</title>
+
+    <!-- config for our rust wasm binary. go to https://trunkrs.dev/assets/#rust for more customization -->
+    <link data-trunk rel="rust" data-wasm-opt="2" />
+    <!-- this is the base url relative to which other urls will be constructed. trunk will insert this from the public-url option -->
+    <base data-trunk-public-url />
+
+
+    <link rel="manifest" href="manifest.json">
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#404040">
+
+    <style>
+        html {
+            /* Remove touch delay: */
+            touch-action: manipulation;
+        }
+
+        body {
+            /* Light mode background color for what is not covered by the egui canvas,
+            or where the egui canvas is translucent. */
+            background: #909090;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                /* Dark mode background color for what is not covered by the egui canvas,
+                or where the egui canvas is translucent. */
+                background: #404040;
+            }
+        }
+
+        /* Allow canvas to fill entire web page: */
+        html,
+        body {
+            overflow: hidden;
+            margin: 0 !important;
+            padding: 0 !important;
+            height: 100%;
+            width: 100%;
+        }
+
+        /* Position canvas in center-top: */
+        canvas {
+            margin-right: auto;
+            margin-left: auto;
+            display: block;
+            position: absolute;
+            top: 0%;
+            left: 50%;
+            transform: translate(-50%, 0%);
+        }
+
+        .centered {
+            margin-right: auto;
+            margin-left: auto;
+            display: block;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            color: #f0f0f0;
+            font-size: 24px;
+            font-family: Ubuntu-Light, Helvetica, sans-serif;
+            text-align: center;
+        }
+
+        /* ---------------------------------------------- */
+        /* Loading animation from https://loading.io/css/ */
+        .lds-dual-ring {
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+        }
+
+        .lds-dual-ring:after {
+            content: " ";
+            display: block;
+            width: 24px;
+            height: 24px;
+            margin: 0px;
+            border-radius: 50%;
+            border: 3px solid #fff;
+            border-color: #fff transparent #fff transparent;
+            animation: lds-dual-ring 1.2s linear infinite;
+        }
+
+        @keyframes lds-dual-ring {
+            0% {
+                transform: rotate(0deg);
+            }
+
+            100% {
+                transform: rotate(360deg);
+            }
+        }
+
+    </style>
+</head>
+
+<body>
+    <!-- The WASM code will resize the canvas dynamically -->
+    <!-- the id is hardcoded in main.rs . so, make sure both match. -->
+    <canvas id="ewebsock_test"></canvas>
+
+    <!--Register Service Worker. this will cache the wasm / js scripts for offline use (for PWA functionality). -->
+    <!-- Force refresh (Ctrl + F5) to load the latest files instead of cached files  -->
+    <script>
+        // We disable caching during development so that we always view the latest version.
+        if ('serviceWorker' in navigator && window.location.hash !== "#dev") {
+            window.addEventListener('load', function () {
+                navigator.serviceWorker.register('sw.js');
+            });
+        }
+    </script>
+</body>
+
+</html>
+
+<!-- Powered by egui: https://github.com/emilk/egui/ -->

--- a/example_app/src/app.rs
+++ b/example_app/src/app.rs
@@ -1,4 +1,7 @@
-use eframe::{egui, epi};
+use eframe::{
+    egui::{self, Context},
+    App,
+};
 use ewebsock::{WsEvent, WsMessage, WsReceiver, WsSender};
 
 #[derive(Default)]
@@ -8,37 +11,44 @@ pub struct ExampleApp {
     frontend: Option<FrontEnd>,
 }
 
-impl epi::App for ExampleApp {
-    fn name(&self) -> &str {
-        "ewebsocket example app"
+impl ExampleApp {
+    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        let mut example_app = ExampleApp {
+            url: "wss://echo.websocket.events/.ws".into(),
+            ..Default::default()
+        };
+
+        example_app.connect(cc.egui_ctx.clone());
+
+        Self::default()
     }
 
-    fn setup(
-        &mut self,
-        _ctx: &egui::Context,
-        frame: &epi::Frame,
-        _storage: Option<&dyn epi::Storage>,
-    ) {
-        if let Some(web_info) = &frame.info().web_info {
-            // allow `?url=` query param
-            if let Some(url) = web_info.location.query_map.get("url") {
-                self.url = url.clone();
+    fn connect(&mut self, ctx: Context) {
+        // We can use this closure to wake up UI thread on new message
+        let wakeup = move || ctx.request_repaint();
+
+        match ewebsock::connect_with_wakeup(&self.url, wakeup) {
+            Ok((ws_sender, ws_receiver)) => {
+                self.frontend = Some(FrontEnd::new(ws_sender, ws_receiver));
+                self.error.clear();
+            }
+            Err(error) => {
+                tracing::error!("Failed to connect to {:?}: {}", &self.url, error);
+                self.error = error;
             }
         }
-        if self.url.is_empty() {
-            self.url = "wss://echo.websocket.events/.ws".into(); // echo server
-        }
-
-        self.connect(frame.clone());
     }
+}
 
-    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
+impl App for ExampleApp {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         if !frame.is_web() {
             egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
                 egui::menu::bar(ui, |ui| {
                     ui.menu_button("File", |ui| {
                         if ui.button("Quit").clicked() {
-                            frame.quit();
+                            #[cfg(not(target_arch = "wasm32"))]
+                            frame.close();
                         }
                     });
                 });
@@ -49,9 +59,9 @@ impl epi::App for ExampleApp {
             ui.horizontal(|ui| {
                 ui.label("URL:");
                 if ui.text_edit_singleline(&mut self.url).lost_focus()
-                    && ui.input().key_pressed(egui::Key::Enter)
+                    && ui.input(|i| i.key_pressed(egui::Key::Enter))
                 {
-                    self.connect(frame.clone());
+                    self.connect(ctx.clone());
                 }
             });
         });
@@ -71,21 +81,7 @@ impl epi::App for ExampleApp {
     }
 }
 
-impl ExampleApp {
-    fn connect(&mut self, frame: epi::Frame) {
-        let wakeup = move || frame.request_repaint(); // wake up UI thread on new message
-        match ewebsock::connect_with_wakeup(&self.url, wakeup) {
-            Ok((ws_sender, ws_receiver)) => {
-                self.frontend = Some(FrontEnd::new(ws_sender, ws_receiver));
-                self.error.clear();
-            }
-            Err(error) => {
-                tracing::error!("Failed to connect to {:?}: {}", &self.url, error);
-                self.error = error;
-            }
-        }
-    }
-}
+impl ExampleApp {}
 
 // ----------------------------------------------------------------------------
 
@@ -115,7 +111,7 @@ impl FrontEnd {
             ui.horizontal(|ui| {
                 ui.label("Message to send:");
                 if ui.text_edit_singleline(&mut self.text_to_send).lost_focus()
-                    && ui.input().key_pressed(egui::Key::Enter)
+                    && ui.input(|i| i.key_pressed(egui::Key::Enter))
                 {
                     self.ws_sender
                         .send(WsMessage::Text(std::mem::take(&mut self.text_to_send)));

--- a/example_app/src/lib.rs
+++ b/example_app/src/lib.rs
@@ -13,13 +13,24 @@ use eframe::wasm_bindgen::{self, prelude::*};
 /// You can add more callbacks like this if you want to call in to your code.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub fn start(canvas_id: &str) -> std::result::Result<(), eframe::wasm_bindgen::JsValue> {
+pub fn start(canvas_id: &str) {
     // Make sure panics are logged using `console.error`.
     console_error_panic_hook::set_once();
 
     // Redirect tracing to console.log and friends:
     tracing_wasm::set_as_global_default();
 
-    let app = ExampleApp::default();
-    eframe::start_web(canvas_id, Box::new(app))
+    let web_options = eframe::WebOptions::default();
+
+    wasm_bindgen_futures::spawn_local(async {
+        eframe::start_web(
+            "ewebsocket example app",
+            web_options,
+            Box::new(|cc| Box::new(ExampleApp::new(cc))),
+        )
+        .await;
+    });
+
+    // let app = ExampleApp::default();
+    // eframe::start_web(canvas_id, Box::new(app))
 }

--- a/example_app/src/main.rs
+++ b/example_app/src/main.rs
@@ -7,25 +7,29 @@
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let app = example_app::ExampleApp::default();
     let native_options = eframe::NativeOptions::default();
-    eframe::run_native(Box::new(app), native_options);
+    eframe::run_native(
+        "ewebsocket example app",
+        native_options,
+        Box::new(|cc| Box::new(example_app::ExampleApp::new(cc))),
+    )
+    .expect("failed to start eframe");
 }
 
 // when compiling to web using trunk.
 #[cfg(target_arch = "wasm32")]
 fn main() {
-    
     console_error_panic_hook::set_once();
     tracing_wasm::set_as_global_default();
 
-    let app = example_app::ExampleApp::default();
+    let web_options = eframe::WebOptions::default();
 
     wasm_bindgen_futures::spawn_local(async {
         eframe::start_web(
-            "ewebsock_test",
-            Box::new(app),
+            "ewebsocket example app",
+            web_options,
+            Box::new(|cc| Box::new(example_app::ExampleApp::new(cc))),
         )
-        .expect("failed to start eframe");
+        .await;
     });
 }

--- a/example_app/src/main.rs
+++ b/example_app/src/main.rs
@@ -11,3 +11,21 @@ async fn main() {
     let native_options = eframe::NativeOptions::default();
     eframe::run_native(Box::new(app), native_options);
 }
+
+// when compiling to web using trunk.
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    
+    console_error_panic_hook::set_once();
+    tracing_wasm::set_as_global_default();
+
+    let app = example_app::ExampleApp::default();
+
+    wasm_bindgen_futures::spawn_local(async {
+        eframe::start_web(
+            "ewebsock_test",
+            Box::new(app),
+        )
+        .expect("failed to start eframe");
+    });
+}


### PR DESCRIPTION
This takes the work started in #9, and updates eframe.

I'm going to start this as a draft PR, since although everything compiles, there are still some areas that I need to fix, and have questions about.

The biggest item is migrating the use of the `App` trait; previously, the `setup` function was used to prepare the websocket listener. Some of the logic in this PR might not be feature similar just yet.

This will close #9.