### PR TITLE
Make tokio an optional dependency, and add `fn ws_receive`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+
+      - name: Check --all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
           args: --all-features
 
       - name: Test doc-tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,12 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +672,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "derivative"
@@ -2058,14 +2058,24 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2141,17 +2151,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.31",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -2421,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -2488,23 +2487,22 @@ checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
  "rand",
  "rustls",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
- "webpki",
  "webpki-roots",
 ]
 
@@ -2781,22 +2779,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
- "webpki",
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,12 +678,6 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "derivative"
@@ -2058,24 +2058,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
-dependencies = [
- "ring",
- "untrusted",
+ "webpki",
 ]
 
 [[package]]
@@ -2151,6 +2141,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.31",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2420,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
@@ -2487,22 +2488,23 @@ checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
+ "base64",
  "byteorder",
  "bytes",
- "data-encoding",
  "http",
  "httparse",
  "log",
  "rand",
  "rustls",
- "sha1",
+ "sha-1",
  "thiserror",
  "url",
  "utf-8",
+ "webpki",
  "webpki-roots",
 ]
 
@@ -2779,12 +2781,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.24.0"
+name = "webpki"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
- "rustls-webpki",
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e493c573fce17f00dcab13b6ac057994f3ce17d1af4dc39bfd482b83c6eb6157"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +927,7 @@ name = "ewebsock"
 version = "0.3.0"
 dependencies = [
  "async-stream",
+ "document-features",
  "futures",
  "futures-util",
  "js-sys",
@@ -1447,6 +1457,12 @@ name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
+name = "litrs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9275e0933cf8bb20f008924c0cb07a0692fe54d8064996520bf998de9eb79aa"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -2386,7 +2386,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2403,16 +2403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,11 +2410,8 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
  "tokio",
- "tokio-rustls",
  "tungstenite",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2500,6 +2487,7 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2776,9 +2764,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+dependencies = [
+ "rustls-webpki",
+]
 
 [[package]]
 name = "winapi"

--- a/check.sh
+++ b/check.sh
@@ -3,6 +3,7 @@
 set -eux
 
 cargo check --workspace --all-targets
+cargo check --workspace --all-targets --all-features
 cargo check -p example_app --all-features --lib --target wasm32-unknown-unknown
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features --  -D warnings -W clippy::all

--- a/echo_server/Cargo.toml
+++ b/echo_server/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 
 
 [dependencies]
-tungstenite = "0.20"
+tungstenite = { version = ">=0.17, <=0.20" }

--- a/echo_server/src/main.rs
+++ b/echo_server/src/main.rs
@@ -9,11 +9,11 @@ fn main() {
             let mut websocket = tungstenite::accept(stream.unwrap()).unwrap();
             eprintln!("New client connected");
             loop {
-                let msg = websocket.read().unwrap();
+                let msg = websocket.read_message().unwrap();
 
                 // We do not want to send back ping/pong messages.
                 if msg.is_binary() || msg.is_text() {
-                    websocket.send(msg).unwrap();
+                    websocket.write_message(msg).unwrap();
                     eprintln!("Responded.");
                 }
             }

--- a/echo_server/src/main.rs
+++ b/echo_server/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // TODO(emilk): Remove when we update tungstenite
+
 use std::{net::TcpListener, thread::spawn};
 
 fn main() {

--- a/ewebsock/Cargo.toml
+++ b/ewebsock/Cargo.toml
@@ -19,15 +19,21 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 
 [features]
-default = ["with_tungstenite"]
-tls = ["tokio-tungstenite/rustls-tls-webpki-roots"]
-with_tungstenite = [
-  "async-stream",
-  "futures-util",
-  "futures",
-  "tokio-tungstenite",
-  "tokio",
-  "tungstenite",
+default = []
+
+tls = ["tungstenite/rustls-tls-webpki-roots"]
+
+## Opt-in to the tokio executor.
+##
+## This adds a lot of dependencies,
+## but may yield lower latency and CPU usage
+## when using `ws_connect`.
+tokio = [
+  "dep:async-stream",
+  "dep:futures",
+  "dep:futures-util",
+  "dep:tokio",
+  "dep:tokio-tungstenite",
 ]
 
 
@@ -36,17 +42,17 @@ log = "0.4"
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tungstenite = { version = ">=0.17, <=0.20" }
 
-# Feature "tungstenite":
+# Optional dependencies for feature "tokio":
 async-stream = { version = "0.3", optional = true }
 futures = { version = "0.3", optional = true }
-futures-util = { version = "0.3", default-features = false, features = [
+futures-util = { version = "0.3", optional = true, default-features = false, features = [
   "sink",
   "std",
-], optional = true }
+] }
 tokio = { version = "1.16", features = ["rt", "sync"], optional = true }
 tokio-tungstenite = { version = ">=0.17, <=0.20", optional = true }
-tungstenite = { version = ">=0.17, <=0.20", optional = true }
 
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ewebsock/Cargo.toml
+++ b/ewebsock/Cargo.toml
@@ -38,6 +38,7 @@ tokio = [
 
 
 [dependencies]
+document-features = "0.2"
 log = "0.4"
 
 # native:

--- a/ewebsock/src/lib.rs
+++ b/ewebsock/src/lib.rs
@@ -12,12 +12,20 @@
 #![warn(missing_docs)] // let's keep ewebsock well-documented
 
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(feature = "with_tungstenite")]
+#[cfg(not(feature = "tokio"))]
 mod native_tungstenite;
 
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(feature = "with_tungstenite")]
+#[cfg(not(feature = "tokio"))]
 pub use native_tungstenite::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "tokio")]
+mod native_tungstenite_tokio;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "tokio")]
+pub use native_tungstenite_tokio::*;
 
 #[cfg(target_arch = "wasm32")]
 mod web;

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -156,6 +156,11 @@ pub fn ws_connect_blocking(
 
     match socket.get_mut() {
         tungstenite::stream::MaybeTlsStream::Plain(stream) => stream.set_nonblocking(true),
+
+        // tungstenite::stream::MaybeTlsStream::NativeTls(stream) => {
+        //     stream.get_mut().set_nonblocking(true)
+        // }
+        #[cfg(feature = "tls")]
         tungstenite::stream::MaybeTlsStream::Rustls(stream) => {
             stream.get_mut().set_nonblocking(true)
         }

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -41,15 +41,7 @@ impl WsSender {
     }
 }
 
-/// Call the given event handler on each new received event.
-///
-/// This is like [`ws_connect`], but it doesn't return a [`WsSender`],
-/// so it can only receive messages, not send them.
-///
-/// # Errors
-/// * On native: failure to spawn receiver thread.
-/// * On web: failure to use `WebSocket` API.
-pub fn ws_receive(url: String, on_event: EventHandler) -> Result<()> {
+pub(crate) fn ws_receive_impl(url: String, on_event: EventHandler) -> Result<()> {
     std::thread::Builder::new()
         .name("ewebsock".to_owned())
         .spawn(move || {
@@ -64,7 +56,7 @@ pub fn ws_receive(url: String, on_event: EventHandler) -> Result<()> {
     Ok(())
 }
 
-/// Call the given event handler on each new received event.
+/// Connect and call the given event handler on each received event.
 ///
 /// Blocking version of [`ws_receive`], only avilable on native.
 ///
@@ -119,14 +111,7 @@ pub fn ws_receiver_blocking(url: &str, on_event: &EventHandler) -> Result<()> {
     }
 }
 
-/// Call the given event handler on each new received event.
-///
-/// This is a more advanced version of [`crate::connect`].
-///
-/// # Errors
-/// * On native: failure to spawn handler thread.
-/// * On web: failure to use `WebSocket` API.
-pub fn ws_connect(url: String, on_event: EventHandler) -> Result<WsSender> {
+pub(crate) fn ws_connect_impl(url: String, on_event: EventHandler) -> Result<WsSender> {
     let (tx, rx) = std::sync::mpsc::channel();
 
     std::thread::Builder::new()
@@ -143,10 +128,9 @@ pub fn ws_connect(url: String, on_event: EventHandler) -> Result<WsSender> {
     Ok(WsSender { tx: Some(tx) })
 }
 
-/// Call the given event handler on each new received event.
+/// Connect and call the given event handler on each received event.
 ///
-/// This is a blocking variant of [`Self::ws_connect`],
-/// only availble on native.
+/// This is a blocking variant of [`ws_connect`], only availble on native.
 ///
 /// # Errors
 /// * Any connection failures

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -31,6 +31,9 @@ impl WsSender {
     ///
     /// This is called automatically when the sender is dropped.
     pub fn close(&mut self) -> Result<()> {
+        if self.tx.is_some() {
+            log::debug!("Closing WebSocket");
+        }
         self.tx = None;
         Ok(())
     }

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // TODO(emilk): Remove when we update tungstenite
+
 use std::sync::mpsc::{Receiver, TryRecvError};
 
 use crate::{EventHandler, Result, WsEvent, WsMessage};

--- a/ewebsock/src/native_tungstenite_tokio.rs
+++ b/ewebsock/src/native_tungstenite_tokio.rs
@@ -1,0 +1,131 @@
+use crate::{EventHandler, Result, WsEvent, WsMessage};
+
+/// This is how you send [`WsMessage`]s to the server.
+///
+/// When this is dropped, the connection is closed.
+pub struct WsSender {
+    tx: Option<tokio::sync::mpsc::Sender<WsMessage>>,
+}
+
+impl Drop for WsSender {
+    fn drop(&mut self) {
+        if let Err(err) = self.close() {
+            log::warn!("Failed to close web-socket: {err:?}");
+        }
+    }
+}
+
+impl WsSender {
+    /// Send a message.
+    ///
+    /// You have to wait for [`WsEvent::Opened`] before you can start sending messages.
+    pub fn send(&mut self, msg: WsMessage) {
+        if let Some(tx) = self.tx.clone() {
+            tokio::spawn(async move { tx.send(msg).await });
+        }
+    }
+
+    /// Close the conenction.
+    ///
+    /// This is called automatically when the sender is dropped.
+    pub fn close(&mut self) -> Result<()> {
+        self.tx = None;
+        Ok(())
+    }
+
+    /// Forget about this sender without closing the connection.
+    pub fn forget(mut self) {
+        std::mem::forget(self.tx.take());
+    }
+}
+
+async fn ws_connect_async(
+    url: String,
+    outgoing_messages_stream: impl futures::Stream<Item = WsMessage>,
+    on_event: EventHandler,
+) {
+    use futures::StreamExt as _;
+
+    let (ws_stream, _) = match tokio_tungstenite::connect_async(url).await {
+        Ok(result) => result,
+        Err(err) => {
+            on_event(WsEvent::Error(err.to_string()));
+            return;
+        }
+    };
+
+    log::info!("WebSocket handshake has been successfully completed");
+    on_event(WsEvent::Opened);
+
+    let (write, read) = ws_stream.split();
+
+    let writer = outgoing_messages_stream
+        .map(|ws_message| match ws_message {
+            WsMessage::Text(text) => tungstenite::protocol::Message::Text(text),
+            WsMessage::Binary(data) => tungstenite::protocol::Message::Binary(data),
+            WsMessage::Ping(data) => tungstenite::protocol::Message::Ping(data),
+            WsMessage::Pong(data) => tungstenite::protocol::Message::Pong(data),
+            WsMessage::Unknown(_) => panic!("You cannot send WsMessage::Unknown"),
+        })
+        .map(Ok)
+        .forward(write);
+
+    let reader = read.for_each(move |event| {
+        match event {
+            Ok(message) => match message {
+                tungstenite::protocol::Message::Text(text) => {
+                    on_event(WsEvent::Message(WsMessage::Text(text)));
+                }
+                tungstenite::protocol::Message::Binary(data) => {
+                    on_event(WsEvent::Message(WsMessage::Binary(data)));
+                }
+                tungstenite::protocol::Message::Ping(data) => {
+                    on_event(WsEvent::Message(WsMessage::Ping(data)));
+                }
+                tungstenite::protocol::Message::Pong(data) => {
+                    on_event(WsEvent::Message(WsMessage::Pong(data)));
+                }
+                tungstenite::protocol::Message::Close(_) => {
+                    on_event(WsEvent::Closed);
+                }
+                tungstenite::protocol::Message::Frame(_) => {}
+            },
+            Err(err) => {
+                on_event(WsEvent::Error(err.to_string()));
+            }
+        };
+        async {}
+    });
+
+    futures_util::pin_mut!(reader, writer);
+    futures_util::future::select(reader, writer).await;
+}
+
+/// Call the given event handler on each new received event.
+///
+/// This is a more advanced version of [`crate::connect`].
+///
+/// # Errors
+/// * On native: never.
+/// * On web: failure to use `WebSocket` API.
+pub fn ws_connect(url: String, on_event: EventHandler) -> Result<WsSender> {
+    Ok(ws_connect_native(url, on_event))
+}
+
+/// Like [`ws_connect`], but cannot fail. Only available on native builds.
+pub fn ws_connect_native(url: String, on_event: EventHandler) -> WsSender {
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1000);
+
+    let outgoing_messages_stream = async_stream::stream! {
+        while let Some(item) = rx.recv().await {
+            yield item;
+        }
+        log::debug!("WsSender dropped - closing connection.");
+    };
+
+    tokio::spawn(async move {
+        ws_connect_async(url.clone(), outgoing_messages_stream, on_event).await;
+        log::debug!("WS connection finished.");
+    });
+    WsSender { tx: Some(tx) }
+}

--- a/ewebsock/src/native_tungstenite_tokio.rs
+++ b/ewebsock/src/native_tungstenite_tokio.rs
@@ -29,6 +29,9 @@ impl WsSender {
     ///
     /// This is called automatically when the sender is dropped.
     pub fn close(&mut self) -> Result<()> {
+        if self.tx.is_some() {
+            log::debug!("Closing WebSocket");
+        }
         self.tx = None;
         Ok(())
     }

--- a/ewebsock/src/native_tungstenite_tokio.rs
+++ b/ewebsock/src/native_tungstenite_tokio.rs
@@ -104,6 +104,7 @@ async fn ws_connect_async(
     futures_util::future::select(reader, writer).await;
 }
 
+#[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ws_connect_impl(url: String, on_event: EventHandler) -> Result<WsSender> {
     Ok(ws_connect_native(url, on_event))
 }

--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -62,27 +62,11 @@ impl WsSender {
     }
 }
 
-/// Call the given event handler on each new received event.
-///
-/// This is like [`ws_connect`], but it doesn't return a [`WsSender`],
-/// so it can only receive messages, not send them.
-///
-/// # Errors
-/// * On native: failure to spawn receiver thread.
-/// * On web: failure to use `WebSocket` API.
-pub fn ws_receive(url: String, on_event: EventHandler) -> Result<()> {
-    ws_connect(url, on_event).map(|sender| sender.forget())
+pub(crate) fn ws_receive_impl(url: String, on_event: EventHandler) -> Result<()> {
+    ws_connect_impl(url, on_event).map(|sender| sender.forget())
 }
 
-/// Call the given event handler on each new received event.
-///
-/// This is a more advanced version of [`crate::connect`].
-///
-/// # Errors
-/// * On native: never.
-/// * On web: failure to use `WebSocket` API.
-#[allow(clippy::needless_pass_by_value)]
-pub fn ws_connect(url: String, on_event: EventHandler) -> Result<WsSender> {
+pub(crate) fn ws_connect_impl(url: String, on_event: EventHandler) -> Result<WsSender> {
     // Based on https://rustwasm.github.io/wasm-bindgen/examples/websockets.html
 
     use wasm_bindgen::closure::Closure;

--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -12,16 +12,15 @@ fn string_from_js_string(s: js_sys::JsString) -> String {
 
 /// This is how you send messages to the server.
 ///
-/// When the last clone of this is dropped, the connection is closed.
-#[derive(Clone)]
+/// When this is dropped, the connection is closed.
 pub struct WsSender {
-    ws: web_sys::WebSocket,
+    ws: Option<web_sys::WebSocket>,
 }
 
 impl Drop for WsSender {
     fn drop(&mut self) {
-        if let Err(err) = self.ws.close() {
-            log::warn!("Failed to close web-socket: {:?}", err);
+        if let Err(err) = self.close() {
+            log::warn!("Failed to close web-socket: {err:?}");
         }
     }
 }
@@ -29,20 +28,50 @@ impl Drop for WsSender {
 impl WsSender {
     /// Send the message to the server.
     pub fn send(&mut self, msg: WsMessage) {
-        let result = match msg {
-            WsMessage::Binary(data) => {
-                self.ws.set_binary_type(web_sys::BinaryType::Blob);
-                self.ws.send_with_u8_array(&data)
+        if let Some(ws) = &mut self.ws {
+            let result = match msg {
+                WsMessage::Binary(data) => {
+                    ws.set_binary_type(web_sys::BinaryType::Blob);
+                    ws.send_with_u8_array(&data)
+                }
+                WsMessage::Text(text) => ws.send_with_str(&text),
+                unknown => {
+                    panic!("Don't know how to send message: {:?}", unknown);
+                }
+            };
+            if let Err(err) = result.map_err(string_from_js_value) {
+                log::error!("Failed to send: {:?}", err);
             }
-            WsMessage::Text(text) => self.ws.send_with_str(&text),
-            unknown => {
-                panic!("Don't know how to send message: {:?}", unknown);
-            }
-        };
-        if let Err(err) = result.map_err(string_from_js_value) {
-            log::error!("Failed to send: {:?}", err);
         }
     }
+
+    /// Close the conenction.
+    ///
+    /// This is called automatically when the sender is dropped.
+    pub fn close(&mut self) -> Result<()> {
+        if let Some(ws) = self.ws.take() {
+            ws.close().map_err(string_from_js_value)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Forget about this sender without closing the connection.
+    pub fn forget(mut self) {
+        self.ws = None;
+    }
+}
+
+/// Call the given event handler on each new received event.
+///
+/// This is like [`ws_connect`], but it doesn't return a [`WsSender`],
+/// so it can only receive messages, not send them.
+///
+/// # Errors
+/// * On native: failure to spawn receiver thread.
+/// * On web: failure to use `WebSocket` API.
+pub fn ws_receive(url: String, on_event: EventHandler) -> Result<()> {
+    ws_connect(url, on_event).map(|sender| sender.forget())
 }
 
 /// Call the given event handler on each new received event.
@@ -143,5 +172,5 @@ pub fn ws_connect(url: String, on_event: EventHandler) -> Result<WsSender> {
         onclose_callback.forget();
     }
 
-    Ok(WsSender { ws })
+    Ok(WsSender { ws: Some(ws) })
 }

--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -20,7 +20,7 @@ pub struct WsSender {
 impl Drop for WsSender {
     fn drop(&mut self) {
         if let Err(err) = self.close() {
-            log::warn!("Failed to close web-socket: {err:?}");
+            log::warn!("Failed to close WebSocket: {err:?}");
         }
     }
 }
@@ -50,6 +50,7 @@ impl WsSender {
     /// This is called automatically when the sender is dropped.
     pub fn close(&mut self) -> Result<()> {
         if let Some(ws) = self.ws.take() {
+            log::debug!("Closing WebSocket");
             ws.close().map_err(string_from_js_value)
         } else {
             Ok(())

--- a/example_app/Cargo.toml
+++ b/example_app/Cargo.toml
@@ -13,6 +13,13 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 
+[features]
+default = []
+
+## Test the tokio backend:
+tokio = ["ewebsock/tokio", "dep:tokio"]
+
+
 [dependencies]
 ewebsock = { path = "../ewebsock", features = ["tls"] }
 
@@ -22,7 +29,11 @@ log = "0.4"
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.10"
-tokio = { version = "1.16", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.16", optional = true, features = [
+    "macros",
+    "rt-multi-thread",
+] }
 
+# web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"

--- a/example_app/src/main.rs
+++ b/example_app/src/main.rs
@@ -2,11 +2,20 @@
 #![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
 #![warn(clippy::all, rust_2018_idioms)]
 
-// When compiling natively:
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() -> eframe::Result<()> {
-    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+    main_impl()
+}
+
+#[cfg(not(feature = "tokio"))]
+fn main() -> eframe::Result<()> {
+    main_impl()
+}
+
+fn main_impl() -> Result<(), eframe::Error> {
+    env_logger::init();
+    // Log to stderr (if you run with `RUST_LOG=debug`).
 
     let app = example_app::ExampleApp::default();
     let native_options = eframe::NativeOptions::default();

--- a/example_app/src/main.rs
+++ b/example_app/src/main.rs
@@ -14,8 +14,7 @@ fn main() -> eframe::Result<()> {
 }
 
 fn main_impl() -> Result<(), eframe::Error> {
-    env_logger::init();
-    // Log to stderr (if you run with `RUST_LOG=debug`).
+    env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
 
     let app = example_app::ExampleApp::default();
     let native_options = eframe::NativeOptions::default();


### PR DESCRIPTION
This strips _a lot_ of dependencies from the native build by default, to make `tokio` opt-in.

It also adds a new `ws_receive` function that is simpler and faster on native, for when you only need to receive message, and never send any.

# TODO
* [x] Use `document-features` crate
* [x] Test with tokio
* [x] Test without tokio
* [x] Test web
* [x] Test with Rerun