### PR TITLE
Report connection error to `on_event` handler on `native_tungstenite` backend

### DIFF
--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -149,6 +149,8 @@ pub fn ws_connect_blocking(
     let (mut socket, response) = match tungstenite::connect(url) {
         Ok(result) => result,
         Err(err) => {
+            let msg = format!("Connect: {err}");
+            on_event(WsEvent::Error(msg));
             return Err(err.to_string());
         }
     };

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -52,6 +52,7 @@ pub(crate) fn ws_receive_impl(url: String, on_event: EventHandler) -> Result<()>
         .spawn(move || {
             if let Err(err) = ws_receiver_blocking(&url, &on_event) {
                 log::error!("WebSocket error: {err}. Connection closed.");
+                on_event(WsEvent::Error(err));
             } else {
                 log::debug!("WebSocket connection closed.");
             }
@@ -71,9 +72,7 @@ pub fn ws_receiver_blocking(url: &str, on_event: &EventHandler) -> Result<()> {
     let (mut socket, response) = match tungstenite::connect(url) {
         Ok(result) => result,
         Err(err) => {
-            let msg = format!("Connect: {err}");
-            on_event(WsEvent::Error(msg));
-            return Err(err.to_string());
+            return Err(format!("Connect: {err}"));
         }
     };
 
@@ -109,7 +108,6 @@ pub fn ws_receiver_blocking(url: &str, on_event: &EventHandler) -> Result<()> {
             },
             Err(err) => {
                 let msg = format!("read: {err}");
-                on_event(WsEvent::Error(msg.clone()));
                 return Err(msg);
             }
         }
@@ -126,6 +124,7 @@ pub(crate) fn ws_connect_impl(url: String, on_event: EventHandler) -> Result<WsS
         .spawn(move || {
             if let Err(err) = ws_connect_blocking(&url, &on_event, &rx) {
                 log::error!("WebSocket error: {err}. Connection closed.");
+                on_event(WsEvent::Error(err));
             } else {
                 log::debug!("WebSocket connection closed.");
             }
@@ -149,9 +148,7 @@ pub fn ws_connect_blocking(
     let (mut socket, response) = match tungstenite::connect(url) {
         Ok(result) => result,
         Err(err) => {
-            let msg = format!("Connect: {err}");
-            on_event(WsEvent::Error(msg));
-            return Err(err.to_string());
+            return Err(format!("Connect: {err}"));
         }
     };
 
@@ -236,7 +233,6 @@ pub fn ws_connect_blocking(
             }
             Err(err) => {
                 let msg = format!("read: {err}");
-                on_event(WsEvent::Error(msg.clone()));
                 return Err(msg);
             }
         }

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -122,7 +122,6 @@ pub(crate) fn ws_connect_impl(url: String, on_event: EventHandler) -> Result<WsS
         .name("ewebsock".to_owned())
         .spawn(move || {
             if let Err(err) = ws_connect_blocking(&url, &on_event, &rx) {
-                log::error!("WebSocket error: {err}. Connection closed.");
                 on_event(WsEvent::Error(err));
             } else {
                 log::debug!("WebSocket connection closed.");

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -51,7 +51,6 @@ pub(crate) fn ws_receive_impl(url: String, on_event: EventHandler) -> Result<()>
         .name("ewebsock".to_owned())
         .spawn(move || {
             if let Err(err) = ws_receiver_blocking(&url, &on_event) {
-                log::error!("WebSocket error: {err}. Connection closed.");
                 on_event(WsEvent::Error(err));
             } else {
                 log::debug!("WebSocket connection closed.");

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -71,6 +71,8 @@ pub fn ws_receiver_blocking(url: &str, on_event: &EventHandler) -> Result<()> {
     let (mut socket, response) = match tungstenite::connect(url) {
         Ok(result) => result,
         Err(err) => {
+            let msg = format!("Connect: {err}");
+            on_event(WsEvent::Error(msg));
             return Err(err.to_string());
         }
     };


### PR DESCRIPTION
This allows for any on_event logic to run when connection fails, since on native, connect will always return OK unless something happened when creating a thread, not when the connection itself fails.