### PR TITLE
Add `protocols` option

### DIFF
--- a/ewebsock/src/lib.rs
+++ b/ewebsock/src/lib.rs
@@ -117,12 +117,13 @@ impl WsReceiver {
 pub type Error = String;
 
 /// Short for `Result<T, ewebsock::Error>`.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub(crate) type EventHandler = Box<dyn Send + Fn(WsEvent) -> std::ops::ControlFlow<()>>;
 
 /// Options for a connection.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Options {
     /// The maximum size of a single incoming message frame, in bytes.
     ///
@@ -131,12 +132,17 @@ pub struct Options {
     ///
     /// Ignored on Web.
     pub max_incoming_frame_size: usize,
+    /// The sub-protocols requested to the server.
+    ///
+    /// This is sent via the `Sec-WebSocket-Protocol` header.
+    pub protocols: Vec<String>,
 }
 
 impl Default for Options {
     fn default() -> Self {
         Self {
             max_incoming_frame_size: 64 * 1024 * 1024,
+            protocols: Vec::new(),
         }
     }
 }

--- a/ewebsock/src/lib.rs
+++ b/ewebsock/src/lib.rs
@@ -123,7 +123,6 @@ pub(crate) type EventHandler = Box<dyn Send + Fn(WsEvent) -> std::ops::ControlFl
 
 /// Options for a connection.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub struct Options {
     /// The maximum size of a single incoming message frame, in bytes.
     ///

--- a/ewebsock/src/native_tungstenite.rs
+++ b/ewebsock/src/native_tungstenite.rs
@@ -2,6 +2,7 @@
 
 use std::sync::mpsc::{Receiver, TryRecvError};
 
+use crate::tungstenite_common::tungstenite_options;
 use crate::{EventHandler, Options, Result, WsEvent, WsMessage};
 
 /// This is how you send [`WsMessage`]s to the server.
@@ -69,11 +70,11 @@ pub(crate) fn ws_receive_impl(url: String, options: Options, on_event: EventHand
 /// # Errors
 /// All errors are returned to the caller, and NOT reported via `on_event`.
 pub fn ws_receiver_blocking(url: &str, options: Options, on_event: &EventHandler) -> Result<()> {
-    let config = tungstenite::protocol::WebSocketConfig::from(options);
+    let (config, request) = tungstenite_options(url, options);
     let max_redirects = 3; // tungstenite default
 
     let (mut socket, response) =
-        match tungstenite::client::connect_with_config(url, Some(config), max_redirects) {
+        match tungstenite::client::connect_with_config(request, Some(config), max_redirects) {
             Ok(result) => result,
             Err(err) => {
                 return Err(format!("Connect: {err}"));
@@ -152,10 +153,11 @@ pub fn ws_connect_blocking(
     on_event: &EventHandler,
     rx: &Receiver<WsMessage>,
 ) -> Result<()> {
-    let config = tungstenite::protocol::WebSocketConfig::from(options);
+    let (config, request) = tungstenite_options(url, options);
     let max_redirects = 3; // tungstenite default
+
     let (mut socket, response) =
-        match tungstenite::client::connect_with_config(url, Some(config), max_redirects) {
+        match tungstenite::client::connect_with_config(request, Some(config), max_redirects) {
             Ok(result) => result,
             Err(err) => {
                 return Err(format!("Connect: {err}"));

--- a/ewebsock/src/native_tungstenite_tokio.rs
+++ b/ewebsock/src/native_tungstenite_tokio.rs
@@ -1,3 +1,4 @@
+use crate::tungstenite_common::tungstenite_options;
 use crate::{EventHandler, Options, Result, WsEvent, WsMessage};
 
 /// This is how you send [`WsMessage`]s to the server.
@@ -51,21 +52,19 @@ async fn ws_connect_async(
 ) {
     use futures::StreamExt as _;
 
-    let config = tungstenite::protocol::WebSocketConfig::from(options);
+    let (config, request) = tungstenite_options(&url, options);
+
     let disable_nagle = false; // God damn everyone who adds negations to the names of their variables
-    let (ws_stream, _) = match tokio_tungstenite::connect_async_with_config(
-        url,
-        Some(config),
-        disable_nagle,
-    )
-    .await
-    {
-        Ok(result) => result,
-        Err(err) => {
-            on_event(WsEvent::Error(err.to_string()));
-            return;
-        }
-    };
+    let (ws_stream, _) =
+        match tokio_tungstenite::connect_async_with_config(request, Some(config), disable_nagle)
+            .await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                on_event(WsEvent::Error(err.to_string()));
+                return;
+            }
+        };
 
     log::info!("WebSocket handshake has been successfully completed");
     on_event(WsEvent::Opened);

--- a/ewebsock/src/tungstenite_common.rs
+++ b/ewebsock/src/tungstenite_common.rs
@@ -1,16 +1,24 @@
-impl From<crate::Options> for tungstenite::protocol::WebSocketConfig {
-    fn from(options: crate::Options) -> Self {
-        let crate::Options {
-            max_incoming_frame_size,
-        } = options;
+use tungstenite::client::IntoClientRequest;
+use tungstenite::handshake::client::Request;
+use tungstenite::protocol::WebSocketConfig;
 
-        tungstenite::protocol::WebSocketConfig {
-            max_frame_size: if max_incoming_frame_size == usize::MAX {
-                None
-            } else {
-                Some(max_incoming_frame_size)
-            },
-            ..Default::default()
-        }
+pub fn tungstenite_options(url: &str, options: crate::Options) -> (WebSocketConfig, Request) {
+    let mut request = url.into_client_request().unwrap();
+    if !options.protocols.is_empty() {
+        let protocols = options.protocols.join(", ").try_into().unwrap();
+        request
+            .headers_mut()
+            .insert("Sec-WebSocket-Protocol", protocols);
     }
+
+    let max_frame_size =
+        (options.max_incoming_frame_size != usize::MAX).then_some(options.max_incoming_frame_size);
+
+    (
+        WebSocketConfig {
+            max_frame_size,
+            ..Default::default()
+        },
+        request,
+    )
 }


### PR DESCRIPTION
Adds an option to set `Sec-WebSocket-Protocol`, which requests a sub-protocol to a server

On web, since its not possible to set any headers when opening a request, this may also be (hackishly) used for authorization