### PR TITLE
Fix crash when error_event does not have "message" or "error" fields

### DIFF
--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -150,8 +150,8 @@ pub(crate) fn ws_connect_impl(
     {
         let on_event = on_event.clone();
         let onerror_callback = Closure::wrap(Box::new(move |error_event: web_sys::ErrorEvent| {
-            let message = js_sys::Reflect::get(&error_event, &"message".into()).unwrap();
-            let error = js_sys::Reflect::get(&error_event, &"error".into()).unwrap();
+            let message = js_sys::Reflect::get(&error_event, &"message".into()).unwrap_or_default();
+            let error = js_sys::Reflect::get(&error_event, &"error".into()).unwrap_or_default();
             log::error!("error event: {:?}: {:?}", message, error);
             on_event(WsEvent::Error(
                 message

--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -150,6 +150,7 @@ pub(crate) fn ws_connect_impl(
     {
         let on_event = on_event.clone();
         let onerror_callback = Closure::wrap(Box::new(move |error_event: web_sys::ErrorEvent| {
+            // using reflect instead of error_event.message() to avoid panic on null
             let message = js_sys::Reflect::get(&error_event, &"message".into()).unwrap_or_default();
             let error = js_sys::Reflect::get(&error_event, &"error".into()).unwrap_or_default();
             log::error!("error event: {:?}: {:?}", message, error);

--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -157,7 +157,7 @@ pub(crate) fn ws_connect_impl(
             on_event(WsEvent::Error(
                 message
                     .as_string()
-                    .unwrap_or_else(|| "Unknown error".to_string()),
+                    .unwrap_or_else(|| "Unknown error".to_owned()),
             ));
         }) as Box<dyn FnMut(web_sys::ErrorEvent)>);
         socket.set_onerror(Some(onerror_callback.as_ref().unchecked_ref()));


### PR DESCRIPTION
Should fix https://github.com/rerun-io/ewebsock/issues/25