### PR TITLE
Fix wasm binary sends causing Blob receives and leaks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"
 rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/rerun-io/ewebsock/compare/latest...HEAD)
+* Fix web binary sends changing the socket's incoming binary type to `Blob`, and release Blob fallback callbacks after `FileReader` finishes.
 
 
 ## 0.8.0 - 2024-11-11 - Fix native performance bug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1177,8 @@ dependencies = [
  "tokio-tungstenite",
  "tungstenite",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 
@@ -1928,6 +1936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2038,16 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -2138,12 +2162,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2459,6 +2493,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -3763,6 +3803,45 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "wasm-encoder"

--- a/ewebsock/Cargo.toml
+++ b/ewebsock/Cargo.toml
@@ -75,3 +75,7 @@ web-sys = { workspace = true, features = [
   "ProgressEvent",
   "WebSocket",
 ] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-futures.workspace = true
+wasm-bindgen-test = "0.3"

--- a/ewebsock/src/web.rs
+++ b/ewebsock/src/web.rs
@@ -1,9 +1,11 @@
 #![allow(trivial_casts)]
 
-use std::{ops::ControlFlow, rc::Rc};
+use std::{cell::RefCell, ops::ControlFlow, rc::Rc};
 use wasm_bindgen::JsValue;
 
 use crate::{EventHandler, Options, Result, WsEvent, WsMessage};
+
+type BlobReadCallback = wasm_bindgen::closure::Closure<dyn FnMut(web_sys::ProgressEvent)>;
 
 #[allow(clippy::needless_pass_by_value)]
 fn string_from_js_value(s: wasm_bindgen::JsValue) -> String {
@@ -34,10 +36,10 @@ impl WsSender {
     pub fn send(&mut self, msg: WsMessage) {
         if let Some(socket) = &mut self.socket {
             let result = match msg {
-                WsMessage::Binary(data) => {
-                    socket.set_binary_type(web_sys::BinaryType::Blob);
-                    socket.send_with_u8_array(&data)
-                }
+                // `binaryType` controls how incoming messages are represented.
+                // Sending bytes must not change it, or future receives can fall
+                // back from `ArrayBuffer` to the slower `Blob` path.
+                WsMessage::Binary(data) => socket.send_with_u8_array(&data),
                 WsMessage::Text(text) => socket.send_with_str(&text),
                 unknown => {
                     panic!("Don't know how to send message: {unknown:?}");
@@ -101,34 +103,7 @@ pub(crate) fn ws_connect_impl(
                 let array = js_sys::Uint8Array::new(&abuf);
                 on_event(WsEvent::Message(WsMessage::Binary(array.to_vec())))
             } else if let Ok(blob) = e.data().dyn_into::<web_sys::Blob>() {
-                // better alternative to juggling with FileReader is to use https://crates.io/crates/gloo-file
-                let file_reader = web_sys::FileReader::new().expect("Failed to create FileReader");
-                let file_reader_clone = file_reader.clone();
-                // create onLoadEnd callback
-                let on_event = on_event.clone();
-                let socket3 = socket2.clone();
-                let onloadend_cb = Closure::wrap(Box::new(move |_e: web_sys::ProgressEvent| {
-                    let control = match file_reader_clone.result() {
-                        Ok(file_reader) => {
-                            let array = js_sys::Uint8Array::new(&file_reader);
-                            on_event(WsEvent::Message(WsMessage::Binary(array.to_vec())))
-                        }
-                        Err(err) => on_event(WsEvent::Error(format!(
-                            "Failed to read binary blob: {}",
-                            string_from_js_value(err)
-                        ))),
-                    };
-                    if control.is_break() {
-                        close_socket(&socket3);
-                    }
-                })
-                    as Box<dyn FnMut(web_sys::ProgressEvent)>);
-                file_reader.set_onloadend(Some(onloadend_cb.as_ref().unchecked_ref()));
-                file_reader
-                    .read_as_array_buffer(&blob)
-                    .expect("blob not readable");
-                onloadend_cb.forget();
-                ControlFlow::Continue(())
+                read_blob_message(&blob, &on_event, socket2.clone())
             } else if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
                 on_event(WsEvent::Message(WsMessage::Text(string_from_js_string(
                     txt,
@@ -202,10 +177,202 @@ pub(crate) fn ws_connect_impl(
     })
 }
 
+fn read_blob_message(
+    blob: &web_sys::Blob,
+    on_event: &Rc<dyn Send + Fn(WsEvent) -> ControlFlow<()>>,
+    socket: Rc<web_sys::WebSocket>,
+) -> ControlFlow<()> {
+    // A higher-level alternative to this FileReader plumbing is gloo-file:
+    // https://crates.io/crates/gloo-file
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast as _;
+
+    let file_reader = web_sys::FileReader::new().expect("Failed to create FileReader");
+    let file_reader_clone = file_reader.clone();
+
+    let cb_holder: Rc<RefCell<Option<BlobReadCallback>>> = Rc::new(RefCell::new(None));
+    let cb_holder_clone = cb_holder.clone();
+    let onloadend_on_event = on_event.clone();
+
+    // `FileReader` is asynchronous, so the callback must stay alive until the
+    // `loadend` event. The callback clears the JS handler and drops itself once
+    // it has fired, avoiding a per-message closure leak on the Blob fallback.
+    let onloadend_cb = Closure::wrap(Box::new(move |_e: web_sys::ProgressEvent| {
+        file_reader_clone.set_onloadend(None);
+
+        let control = match file_reader_clone.result() {
+            Ok(file_reader) => {
+                let array = js_sys::Uint8Array::new(&file_reader);
+                onloadend_on_event(WsEvent::Message(WsMessage::Binary(array.to_vec())))
+            }
+            Err(err) => onloadend_on_event(WsEvent::Error(format!(
+                "Failed to read binary blob: {}",
+                string_from_js_value(err)
+            ))),
+        };
+        if control.is_break() {
+            close_socket(&socket);
+        }
+
+        cb_holder_clone.borrow_mut().take();
+    }) as Box<dyn FnMut(web_sys::ProgressEvent)>);
+
+    file_reader.set_onloadend(Some(onloadend_cb.as_ref().unchecked_ref()));
+    *cb_holder.borrow_mut() = Some(onloadend_cb);
+
+    if let Err(err) = file_reader.read_as_array_buffer(blob) {
+        file_reader.set_onloadend(None);
+        cb_holder.borrow_mut().take();
+        on_event(WsEvent::Error(format!(
+            "Failed to read binary blob: {}",
+            string_from_js_value(err)
+        )))
+    } else {
+        ControlFlow::Continue(())
+    }
+}
+
 fn close_socket(socket: &web_sys::WebSocket) {
     if let Err(err) = socket.close() {
         log::warn!("Failed to close WebSocket: {}", string_from_js_value(err));
     } else {
         log::debug!("Closed WebSocket");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use wasm_bindgen::prelude::wasm_bindgen;
+    use wasm_bindgen_futures::JsFuture;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    use super::*;
+
+    // The real Blob fallback depends on the browser's asynchronous `FileReader`.
+    // This fake keeps the same shape but makes the result deterministic and
+    // lets the test inspect whether Rust released the `onloadend` handler.
+    #[wasm_bindgen(inline_js = r#"
+        export function install_fake_file_reader() {
+            globalThis.__ewebsockOriginalFileReader = globalThis.FileReader;
+            globalThis.__ewebsockLastFileReader = undefined;
+            globalThis.FileReader = class {
+                constructor() {
+                    this.onloadend = null;
+                    this.result = null;
+                    globalThis.__ewebsockLastFileReader = this;
+                }
+
+                readAsArrayBuffer(_blob) {
+                    Promise.resolve().then(() => {
+                        this.result = new Uint8Array([4, 5, 6]).buffer;
+                        const onloadend = this.onloadend;
+                        if (onloadend) {
+                            onloadend.call(this, new ProgressEvent("loadend"));
+                        }
+                    });
+                }
+            };
+        }
+
+        export function restore_file_reader() {
+            globalThis.FileReader = globalThis.__ewebsockOriginalFileReader;
+            delete globalThis.__ewebsockOriginalFileReader;
+            delete globalThis.__ewebsockLastFileReader;
+        }
+
+        export function last_file_reader_onloadend_is_null() {
+            const reader = globalThis.__ewebsockLastFileReader;
+            return !!reader && reader.onloadend == null;
+        }
+
+        export function next_tick() {
+            return new Promise(resolve => setTimeout(resolve, 0));
+        }
+    "#)]
+    extern "C" {
+        fn install_fake_file_reader();
+        fn restore_file_reader();
+        fn last_file_reader_onloadend_is_null() -> bool;
+        fn next_tick() -> js_sys::Promise;
+    }
+
+    thread_local! {
+        // `EventHandler` is `Send` for API parity with native, but wasm tests run
+        // on one browser thread. Thread-local storage keeps the test handler simple
+        // without introducing synchronization primitives that do not matter here.
+        static EVENTS: RefCell<Vec<WsEvent>> = const { RefCell::new(Vec::new()) };
+    }
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn sending_binary_does_not_change_incoming_binary_type() {
+        // No server needs to accept this connection. The bug was synchronous:
+        // constructing `WsSender` around a browser WebSocket and calling
+        // `send(Binary)` changed the socket's incoming binary representation.
+        let socket = match web_sys::WebSocket::new("ws://127.0.0.1:1") {
+            Ok(socket) => socket,
+            Err(err) => panic!("failed to create websocket: {err:?}"),
+        };
+        socket.set_binary_type(web_sys::BinaryType::Arraybuffer);
+
+        let mut sender = WsSender {
+            socket: Some(Rc::new(socket.clone())),
+        };
+        sender.send(WsMessage::Binary(vec![1, 2, 3]));
+
+        // `binaryType` only controls incoming messages. A send must leave it
+        // alone so future binary receives stay on the ArrayBuffer fast path.
+        assert_eq!(socket.binary_type(), web_sys::BinaryType::Arraybuffer);
+
+        sender.close();
+    }
+
+    #[wasm_bindgen_test]
+    async fn blob_reader_clears_onloadend_after_dispatch() {
+        install_fake_file_reader();
+
+        // The socket is only used if the callback asks to close the connection;
+        // this test keeps the handler on `Continue`, so no live server is needed.
+        let socket = match web_sys::WebSocket::new("ws://127.0.0.1:1") {
+            Ok(socket) => Rc::new(socket),
+            Err(err) => panic!("failed to create websocket: {err:?}"),
+        };
+        EVENTS.with(|events| events.borrow_mut().clear());
+        let on_event: Rc<dyn Send + Fn(WsEvent) -> ControlFlow<()>> = Rc::new(|event| {
+            EVENTS.with(|events| events.borrow_mut().push(event));
+            ControlFlow::Continue(())
+        });
+        let blob = match web_sys::Blob::new() {
+            Ok(blob) => blob,
+            Err(err) => panic!("failed to create blob: {err:?}"),
+        };
+
+        let control = read_blob_message(&blob, &on_event, socket.clone());
+        assert!(control.is_continue());
+
+        // Wait for the fake FileReader to schedule and fire `loadend`.
+        if let Err(err) = JsFuture::from(next_tick()).await {
+            panic!("failed to wait for fake FileReader: {err:?}");
+        }
+
+        // The handler slot must be cleared after `loadend`; otherwise the
+        // FileReader and Rust closure can keep each other alive per Blob message.
+        assert!(last_file_reader_onloadend_is_null());
+
+        // The cleanup must not change behavior: the Blob is still delivered as
+        // the original binary message payload.
+        let events = EVENTS.with(|events| events.borrow().clone());
+        match events.as_slice() {
+            [WsEvent::Message(WsMessage::Binary(data))] => {
+                assert_eq!(data.as_slice(), &[4, 5, 6]);
+            }
+            events => panic!("unexpected events: {events:?}"),
+        }
+
+        restore_file_reader();
+        close_socket(&socket);
     }
 }


### PR DESCRIPTION
The web backend was setting WebSocket.binaryType to Blob while sending WsMessage::Binary. That property only controls incoming message representation, so a binary send could force later binary receives through the Blob fallback instead of the intended ArrayBuffer path.

That fallback used FileReader with a forgotten closure per Blob message, so this could also leak memory over repeated binary receives.

Keep binary sends side-effect free, retain Blob FileReader callbacks only until loadend, and add wasm browser tests for both the binaryType regression and FileReader callback cleanup.